### PR TITLE
Kafka keystore volume use should be guarded as well

### DIFF
--- a/charts/callisto-base-service/Chart.yaml
+++ b/charts/callisto-base-service/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1

--- a/charts/callisto-base-service/templates/deployment.yaml
+++ b/charts/callisto-base-service/templates/deployment.yaml
@@ -49,9 +49,11 @@ spec:
             {{- if .Values.db }}
             {{- include "callisto-base-service.dbEnvironmentVariables" . | nindent 12 }}
             {{- end }}
+          {{- if .Values.kafka }}
           volumeMounts:
             - mountPath: /keystore
               name: keystore-volume
+          {{- end }}
       initContainers:
         {{- if .Values.db }}
         - name: database-schema-creation


### PR DESCRIPTION
The main container should refer to `keystore-volume` volume only when it was declared to begin with, which is equivalent to the case when Kafka values are provided.