### PR TITLE
Add Kafka permission groups to Helm chart and document known issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,7 @@ ingress:
   tlsSecretName: callisto-accruals-tls
   corsOrigin: "https://*.dev.callisto-notprod.homeoffice.gov.uk"
 ```
+
+## Known issue
+[Kafka SSL Certificate Rotation](https://github.com/UKHomeOffice/callisto-helm-charts/issues/10)
+[Add network policy rules](https://github.com/UKHomeOffice/callisto-helm-charts/issues/11)

--- a/charts/callisto-base-service/Chart.yaml
+++ b/charts/callisto-base-service/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4


### PR DESCRIPTION
- Add Kafka permission groups to Helm chart
- Document the following issues in README:
    - Implement Kafka SSL certificate rotation
    - Add network policy rules to base Helm chart 